### PR TITLE
Add root path and landing page for app.

### DIFF
--- a/app/assets/javascripts/static_pages.js.coffee
+++ b/app/assets/javascripts/static_pages.js.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/static_pages.css.scss
+++ b/app/assets/stylesheets/static_pages.css.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the StaticPages controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,0 +1,6 @@
+class StaticPagesController < ApplicationController
+
+  def index
+  end
+  
+end

--- a/app/helpers/static_pages_helper.rb
+++ b/app/helpers/static_pages_helper.rb
@@ -1,0 +1,2 @@
+module StaticPagesHelper
+end

--- a/app/views/static_pages/index.html.erb
+++ b/app/views/static_pages/index.html.erb
@@ -1,0 +1,3 @@
+<h1>Welcome to Intergalactic Battleship!</h1>
+
+<p>may the binks be with you.</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ IntergalacticBattleship::Application.routes.draw do
   # See how all your routes lay out with "rake routes".
 
   # You can have the root of your site routed with "root"
-  # root 'welcome#index'
+  root 'static_pages#index'
 
   # Example of regular route:
   #   get 'products/:id' => 'catalog#view'

--- a/spec/controllers/static_pages_controller_spec.rb
+++ b/spec/controllers/static_pages_controller_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe StaticPagesController, type: :controller do
+  
+  describe "static_pages#index" do
+    it "should be displayed to a user" do
+      get :index
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/helpers/static_pages_helper_spec.rb
+++ b/spec/helpers/static_pages_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the StaticPagesHelper. For example:
+#
+# describe StaticPagesHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe StaticPagesHelper, type: :helper do
+  
+end


### PR DESCRIPTION
Set `root_path` for application, create view for `index` action.

I think the lack of a root path for the application may be why it still won't deploy to heroku. If you look at production right now, you'll see that it says there's nothing there.
